### PR TITLE
fix parallax for finite items

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -28,7 +28,7 @@ Different sizes
 
 ## 0.0.29
 
-_Current_
+_02/01/2026_
 
 Added vertical slider support
 
@@ -37,3 +37,27 @@ Added vertical slider support
 - Updated keyboard navigation to use ArrowUp/ArrowDown for vertical mode
 - All features (infinite, snap, variable width, etc.) now work in both orientations
 - Added vertical slider example component and documentation
+
+## 0.0.30
+
+_05/01/2026_
+
+Added tests and fixed globalName issue
+
+- Fixed globalName utility
+- Added test infrastructure
+
+## 0.0.31
+
+_05/01/2026_
+
+Version bump
+
+## 0.0.32
+
+_Current_
+
+Added tests and build improvements
+
+- Added build test infrastructure
+- Build improvements and fixes

--- a/web/src/components/vanilla/VanillaFinite.astro
+++ b/web/src/components/vanilla/VanillaFinite.astro
@@ -19,7 +19,9 @@ const slides = Array.from({ length: 10 }, (_, i) => i)
       <div class="flex aspect-[3/4] w-[80vw] shrink-0 items-center justify-center p-1 md:w-[30vw]">
         <div class="relative h-full w-full p-8 outline outline-gray-700">
           <p class="absolute top-2 left-2 z-10">{i}</p>
-          <div data-parallax class="h-full w-full outline outline-gray-800" />
+          <div data-parallax class="h-full w-full outline outline-gray-800">
+            <p>0</p>
+          </div>
         </div>
       </div>
     ))
@@ -31,14 +33,26 @@ const slides = Array.from({ length: 10 }, (_, i) => i)
 
   const s1 = document.querySelector("[data-slider='vanilla-finite']")
   if (s1) {
+    const parallaxes = [...s1.querySelectorAll("[data-parallax]")]
+    const pValues = parallaxes.map(p => p.querySelector("p"))
+
     const onSlideChange = (slide, previous) => {
       slider.items[previous].children[0].classList.remove("active")
       slider.items[slide].children[0].classList.add("active")
     }
 
     const onUpdate = slider => {
-      // console.log(slider.progress)
-      // console.log(Math.abs(slider.current / (slider.items.length - 1)))
+      const { parallaxValues } = slider
+
+      parallaxes.forEach((parallax, i) => {
+        console.log(`Parallax ${i}:`, parallaxValues[i])
+        if (parallax instanceof HTMLElement) {
+          parallax.style.transform = `translateX(${parallaxValues[i] * 10}%)`
+        }
+        if (pValues[i]) {
+          pValues[i].textContent = parallaxValues[i].toFixed(2)
+        }
+      })
     }
 
     const slider = new Slider(s1, { infinite: false, onSlideChange, onUpdate })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improves correctness and performance of the slider core, and updates the demo/docs.
> 
> - **Core**: Fixes finite-mode parallax; refactors `#updateFinite`, `#updateInfinite`, and variable-width variants to compute `parallaxValues` and only write transforms when change exceeds `config.domUpdateThreshold` using `#lastAppliedTranslates`.
> - **Resource cleanup**: Stores listener/observer refs for proper removal in `destroy()`; adds `ResizeObserver` field and disconnects it.
> - **Viewport/setup**: Optimizes size/offset calculations with single-pass loops and caches counts; keeps `setOffset` signature and maxScroll math intact.
> - **API/config**: Adds `domUpdateThreshold` to `CoreConfig` defaults and ensures `parallaxValues` array via `#ensureParallaxValues`.
> - **Demo**: Updates `VanillaFinite.astro` to transform elements using `parallaxValues` and display current values.
> - **Docs**: Updates `changelog.md` with new versions and notes on tests/build improvements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4892976c9407f4cc63700a51d26f592239239c5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->